### PR TITLE
add leftMin/leftLock/rightLock option for range

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Here's a quick example to get you started:
  disabled | bool | false |
  onChange | func |  | Callback fired when the value is changed.<br>__Signature:__ <br> function(value: number/array[number,number]) => void
  onChangeComplete | func |  | Callback fired when the value is changed completely.<br>__Signature:__ <br> function(value: number/array[number,number]) => void
+ leftMin | number | 0 | min value for range selection
+ leftLock | bool | false | allow/not allow scroll left for range
+ rightLock | bool | false | allow/not allow scroll right for range
 
 ## Update 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # Slider for Material-UI 1.0.0
-This is an alternative package fork from [material-ui-slider](https://www.npmjs.com/package/material-ui-slider)
-We add 3 more props, and make a PR to the master branch.
-This package is for temporary use within our own development
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Slider for Material-UI 1.0.0
+This is an alternative package fork from [material-ui-slider](https://www.npmjs.com/package/material-ui-slider)
+We add 3 more props, and make a PR to the master branch.
+This package is for temporary use within our own development
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -25,15 +25,19 @@
     "deploy": "./builds/scripts/deploy.sh"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.4.0",
     "classnames": "^2.2.5",
     "lodash": "^4.17.10",
     "prop-types": "^15.6.1",
     "raf": "^3.4.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.2.3",
+    "@babel/core": "^7.4.0",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.1.0",
+    "@babel/preset-env": "^7.4.1",
     "@babel/standalone": "^7.0.0",
     "@material-ui/core": "^3.3.1",
     "@material-ui/icons": "^3.0.1",

--- a/src/slider/Slider.jsx
+++ b/src/slider/Slider.jsx
@@ -99,7 +99,10 @@ class Slider extends Component{
     scale:0,
     direction:'horizontal',
     onChange:()=>{},
-    onChangeComplete:()=>{}
+    onChangeComplete:()=>{},
+    leftLock: false,
+    rightLock: false,
+    leftMin: null
   }
 
   min;
@@ -191,24 +194,29 @@ class Slider extends Component{
   }
   
   handleChange = (e, skip)=>{
-    const {range, disabled} = this.props;
+    const {range, disabled, leftLock, rightLock, leftMin} = this.props;
     const {min, max} = this;
     if(disabled) return;
 
     const offset = calculateChange(e,skip,this.props,this.container);
     const oldValue = this.state.value;
-    const newValue = this.calcScaleValue(Math.round(offset/100*((max-min)))+min);    
+    const newValueCal = this.calcScaleValue(Math.round(offset/100*((max-min)))+min);
+    const newValue = (leftMin && newValueCal < leftMin) ? leftMin : newValueCal;
     if(range){
       if((this.activePointer==='left' && oldValue[0] !== newValue && newValue < oldValue[1]) || newValue <= oldValue[0] ){
         this.activePointer==='right'&&(this.activePointer='left');
-        this.setState({
-          value:[newValue,oldValue[1]]
-        },()=>{this.triggerChange(e)})
+        if (!leftLock) {
+          this.setState({
+            value:[newValue,oldValue[1]]
+          },()=>{this.triggerChange(e)})
+        }
       }else if((this.activePointer==='right' && oldValue[1] !== newValue && newValue > oldValue[0])|| newValue >= oldValue[1]) {
         this.activePointer==='left'&&(this.activePointer='right');
-        this.setState({
-          value:[oldValue[0],newValue]
-        },()=>{this.triggerChange(e)})
+        if (!rightLock) {
+          this.setState({
+            value:[oldValue[0],newValue]
+          },()=>{this.triggerChange(e)})
+        }
       }
     }else{         
       if(oldValue !== newValue)
@@ -516,7 +524,10 @@ Slider.propTypes={
   color: PropTypes.string,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
-  onChangeComplete: PropTypes.func
+  onChangeComplete: PropTypes.func,
+  leftLock: PropTypes.bool,
+  rightLock: PropTypes.bool,
+  leftMin: PropTypes.number
 }
 
 export default withStyles(styles,{withTheme:true})(Slider)

--- a/src/slider/Slider.jsx
+++ b/src/slider/Slider.jsx
@@ -102,7 +102,7 @@ class Slider extends Component{
     onChangeComplete:()=>{},
     leftLock: false,
     rightLock: false,
-    leftMin: null
+    leftMin: 0
   }
 
   min;


### PR DESCRIPTION
add 3 prop options for range
- leftMin: the min and max is the selectable range to show on the graph, but sometimes, we want to show the range [0,100], but we only allow user to select from [40,100], the `leftMin` is the option to do it
- leftLock/rightLock: similar to above, for user, the interface is a range, but sometimes we want to lock the left or right not to allow them to change 